### PR TITLE
Add useNativeDriver to remove warning from RN 0.62

### DIFF
--- a/FadeInView.js
+++ b/FadeInView.js
@@ -20,6 +20,7 @@ class FadeInView extends Component {
       {
         toValue: 1,
         duration,
+        useNativeDriver: false,
       },
     ).start(onFadeComplete || (() => {}));
   }


### PR DESCRIPTION
After update to react-native 0.62, i have now a warning triggered when i use fade-in-view. useNativeDriver needs to be specified now.